### PR TITLE
[lib/test.js] Support URLs without leading slash

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -7,7 +7,7 @@ var util = require('util');
 var http = require('http');
 var https = require('https');
 var assert = require('assert');
-var url = require('url')
+var url = require('url');
 var Request = request.Request;
 
 /**

--- a/lib/test.js
+++ b/lib/test.js
@@ -7,6 +7,7 @@ var util = require('util');
 var http = require('http');
 var https = require('https');
 var assert = require('assert');
+var url = require('url')
 var Request = request.Request;
 
 /**
@@ -59,7 +60,7 @@ Test.prototype.serverAddress = function(app, path, host) {
   if (!addr) this._server = app.listen(0);
   port = app.address().port;
   protocol = app instanceof https.Server ? 'https' : 'http';
-  return protocol + '://' + (host || '127.0.0.1') + ':' + port + path;
+  return url.resolve(protocol + '://' + (host || '127.0.0.1') + ':' + port, path);
 };
 
 /**


### PR DESCRIPTION
I hit a weird issue and a cryptic error message when using this library. Decided to fix to simplify its usage.

Test Code:
```js
import app from '../../../app'; // a plain old express app
import request from 'supertest';

test('happy path: ', async () => {
  const agent = request.agent(app);
  const res = await agent
    .get('api/tenants/startauth');
});

```

Output:
```
  ● happy path: 

    connect ECONNREFUSED 0.0.0.0:80

       7 |   const agent = request.agent(app);
       8 |   const res = await agent
    >  9 |     .host('0.0.0.0')
         |                                         ^
      10 |     .get('api/tenants/startauth');
      11 |     
```

Adding a leading slash to my get call fixed the problem. But with additional logging, I noticed the [serverAddress function](https://github.com/visionmedia/supertest/blob/master/lib/test.js#L54) returned the invalid URL `http://127.0.0.1:57625api/tenants/startauth`.

This PR allows for the leading slash to be optional, fixing the URL generation and makes the cryptic error go away -- a better experience for all users of this library.
