### PR TITLE
changed inspect depth for testing deeply nested objects

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -200,14 +200,14 @@ Test.prototype._assertBody = function(body, res) {
     try {
       assert.deepStrictEqual(body, res.body);
     } catch (err) {
-      a = util.inspect(body);
-      b = util.inspect(res.body);
+      a = util.inspect(body, { depth: null });
+      b = util.inspect(res.body, { depth: null });
       return error('expected ' + a + ' response body, got ' + b, body, res.body);
     }
   } else if (body !== res.text) {
     // string
-    a = util.inspect(body);
-    b = util.inspect(res.text);
+    a = util.inspect(body, { depth: null });
+    b = util.inspect(res.text, { depth: null });
 
     // regexp
     if (isregexp) {


### PR DESCRIPTION
Allows more deeply nested objects to be tested. At the moment the depth is capped at 2 which is the default depth value of util.inspect().