### PR TITLE
Compose urls in `Test.serverAddress` using Node's `url` library

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -3,6 +3,7 @@
  */
 
 var request = require('superagent');
+var url = require('url');
 var util = require('util');
 var http = require('http');
 var https = require('https');
@@ -51,7 +52,7 @@ Object.setPrototypeOf(Test.prototype, Request.prototype);
  * @api private
  */
 
-Test.prototype.serverAddress = function(app, path, host) {
+Test.prototype.serverAddress = function(app, pathname, hostname = '127.0.0.1') {
   var addr = app.address();
   var port;
   var protocol;
@@ -59,7 +60,13 @@ Test.prototype.serverAddress = function(app, path, host) {
   if (!addr) this._server = app.listen(0);
   port = app.address().port;
   protocol = app instanceof https.Server ? 'https' : 'http';
-  return protocol + '://' + (host || '127.0.0.1') + ':' + port + path;
+
+  return url.format({
+    protocol,
+    hostname,
+    port,
+    pathname
+  });
 };
 
 /**


### PR DESCRIPTION
When making supertest calls with URLs that do not start with a slash, all sorts of wacky errors can result due to the way the serverAddress is composed via string concatenation.

Using Node's `url` library will give more reliable and error-resilient results.