### PR TITLE
fix: wait for ephemeral server to listen before dispatching request

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -133,7 +133,7 @@ class Test extends Request {
   end(fn) {
     const server = this._server;
 
-    super.end((err, res) => {
+    const dispatch = () => super.end((err, res) => {
       const localAssert = () => {
         this.assert(err, res, fn);
       };
@@ -155,6 +155,13 @@ class Test extends Request {
 
       localAssert();
     });
+
+    if (server && !server.listening) {
+      server.once('listening', dispatch);
+      return this;
+    }
+
+    dispatch();
 
     return this;
   }

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const http = require('http');
 const https = require('https');
 let http2;
 try {
@@ -14,6 +15,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const nock = require('nock');
+const { Request } = require('superagent');
 const request = require('../index.js');
 const throwError = require('./throwError');
 
@@ -251,6 +253,60 @@ describe('request(app)', function () {
   });
 
   describe('.end(fn)', function () {
+    let originalEnd;
+
+    beforeEach(function () {
+      originalEnd = Request.prototype.end;
+    });
+
+    afterEach(function () {
+      Request.prototype.end = originalEnd;
+    });
+
+    it('should wait for server to listen before sending request', function (done) {
+      const server = http.createServer();
+      let addressAvailable = false;
+      let listening = false;
+
+      Object.defineProperty(server, 'listening', {
+        configurable: true,
+        get() {
+          return listening;
+        }
+      });
+      server.address = function () {
+        return addressAvailable ? { port: 1 } : null;
+      };
+      server.listen = function () {
+        addressAvailable = true;
+        return server;
+      };
+      Request.prototype.end = function (fn) {
+        if (!listening) {
+          done(new Error('request dispatched before server was listening'));
+          return this;
+        }
+
+        fn(null, { status: 200, header: {}, text: 'supertest FTW!' });
+        return this;
+      };
+
+      try {
+        request(server)
+          .get('/')
+          .end(function (err, res) {
+            if (err) return done(err);
+            res.text.should.equal('supertest FTW!');
+            done();
+          });
+
+        listening = true;
+        server.emit('listening');
+      } catch (err) {
+        done(err);
+      }
+    });
+
     it('should close server', function (done) {
       const app = express();
       let test;


### PR DESCRIPTION
 Fix #255

When an app is passed to supertest, request(app) starts a temporary server with app.listen(0) and builds the URL from server.address().port. The port is instantly ready before the server emits 'listening', so if superagent dispatches in that window the request misses the app and returns a 404. That's why the route in #255 works from other clients but intermittently 404s under supertest. That's why starting a server outside of the supertest (with waiting for 'listening' event)  also fixes the issue.

This PR waits for the server's 'listening' event before dispatching, but only when supertest started the server and it isn't listening yet. A regression test covers the race window, fails without fix, passes with the fix.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

